### PR TITLE
correct $platform: if on cygwin when tcl/tk is on unix

### DIFF
--- a/lib/Tcl/pTk.pm
+++ b/lib/Tcl/pTk.pm
@@ -822,6 +822,11 @@ sub new {
     # Create background error handling method that is similar to the way perltk does it
     $tkinterp->CreateCommand('bgerror', \&Tcl::pTk::bgerror);
 
+    # correct $platform: if we're on 'cygwin' but tcl/tk is on 'unix', then platform is 'unix':
+    if($^O eq 'cygwin' && $i->GetVar2('tcl_platform','platform') eq 'unix') {
+        $platform = 'unix';
+    }
+
     # RT #127120: Middle-click paste workaround
     # for older Tcl/Tk versions on macOS aqua
     if ($i->Eval('tk windowingsystem') eq 'aqua') {


### PR DESCRIPTION
it was earlier that 'cygwin' perl uses 'windows'-based tcl/tk; currently I can not reproduce this setup anymore;
however when I've tried perl-tcl-ptk on cygwin with both perl and tcl/tk cygwin-based, I got following failure:
```
Test Summary Report
-------------------
t/browseEntry.t             (Wstat: 2816 Tests: 0 Failed: 0)
  Non-zero exit status: 11
  Parse errors: Bad plan.  You planned 2 tests but ran 0.
t/browseEntry2.t            (Wstat: 2816 Tests: 5 Failed: 2)
  Failed tests:  4-5
  Non-zero exit status: 11
  Parse errors: Bad plan.  You planned 22 tests but ran 5.
```

I even think cygwin setup with cygwin tcl/tk is more common these days