### PR TITLE
Support ttk::treeview cellselection command

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Summary of Changes to Tcl::pTk
 
 1.08_03  2021-mm-dd
 
+ * Support ttk::treeview `cellselection` command (Tk 8.7 TIP 552)
 
 1.08_02  2021-04-04
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -140,6 +140,9 @@ my %makeArgs = (
         'Sub::Name' => '0.05',
         'Time::HiRes' => 0,
     },
+    TEST_REQUIRES => {
+        'Test::Deep' => 0,
+    },
 );
 
 # Remove META_MERGE parameter for older versions of ExtUtils::MakeMaker
@@ -148,6 +151,7 @@ my $MMversion = $ExtUtils::MakeMaker::VERSION;
 $MMversion =~ s/_\d+$//; # Get rid of underscores in the version for numeric compare
 delete $makeArgs{META_MERGE} if( $MMversion < 6.45 );
 delete $makeArgs{MIN_PERL_VERSION} if ( $MMversion < 6.48 );
+delete $makeArgs{TEST_REQUIRES} if ( $MMversion < 6.64 );
 
 WriteMakefile(
 %makeArgs

--- a/lib/Tcl/pTk/Tile.pm
+++ b/lib/Tcl/pTk/Tile.pm
@@ -204,6 +204,10 @@ sub Tcl::pTk::ttkTreeview::tag {
     my $self = shift;
     $self->call($self->path, 'tag', @_);
 }
+sub Tcl::pTk::ttkTreeview::cellselection {
+    my $self = shift;
+    $self->call($self->path, 'cellselection', @_);
+}
 
 1;
 


### PR DESCRIPTION
Tcl/Tk 8.7 implements [TIP 552](https://core.tcl-lang.org/tips/doc/trunk/tip/552.md) which includes adding a new Ttk Treeview command `cellselection` which returns a list and so likely needs to be wrapped just as `selection`, etc. currently are.

A test should be implemented (will need to skip if not using 8.7 or later).